### PR TITLE
refactor: enable lazy loaded routes

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { CommonModule } from '@angular/common';
@@ -12,7 +12,15 @@ import { LogService } from './service/log.service';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, HeaderComponent, FooterComponent, CommonModule, ToastModule, CookiesComponent],
+  standalone: true,
+  imports: [
+    RouterModule,
+    HeaderComponent,
+    FooterComponent,
+    CommonModule,
+    ToastModule,
+    CookiesComponent
+  ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,7 +1,5 @@
-import { ApplicationConfig, LOCALE_ID, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { ApplicationConfig, LOCALE_ID, provideZoneChangeDetection, importProvidersFrom } from '@angular/core';
 import { provideToastr } from 'ngx-toastr';
-import { routes } from './app.routes';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { providePrimeNG } from 'primeng/config';
@@ -12,11 +10,15 @@ import { provideNgxMask } from 'ngx-mask';
 import { registerLocaleData } from '@angular/common';
 import localePt from '@angular/common/locales/pt';
 import { SecretInterceptor } from './interceptors/secret.interceptor';
+import { RouterModule, PreloadAllModules } from '@angular/router';
+import { routes } from './app.routes';
 registerLocaleData(localePt);
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes),
+    importProvidersFrom(
+      RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules })
+    ),
     provideHttpClient(
       withInterceptors([SecretInterceptor])
     ),

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,61 +1,59 @@
 import { Routes } from '@angular/router';
-import { AuthCallbackComponent } from './components/auth-callback/auth-callback.component';
 import { AuthGuard } from './auth.guard';
-import { DashboardComponent } from './pages/dashboard/dashboard.component';
-import { InicioComponent } from './pages/inicio/inicio.component';
-import { NotFoundComponent } from './pages/not-found/not-found.component';
-import { RegistroComponent } from './pages/registro/registro.component';
-import { AllowlistComponent } from './pages/allowlist/allowlist.component';
 import { allowlistGuard } from './allowlist.guard';
-import { TermsComponent } from './components/terms/terms.component';
-import { PolicyComponent } from './components/policy/policy.component';
-import { PolicyCookiesComponent } from './components/policy-cookies/policy-cookies.component';
-import { TicketComponent } from './components/ticket/ticket.component';
 
 export const routes: Routes = [
   {
     path: '',
-    component: InicioComponent
+    loadComponent: () =>
+      import('./pages/inicio/inicio.component').then((m) => m.InicioComponent)
   },
   {
     path: 'home',
-    component: InicioComponent
+    loadComponent: () =>
+      import('./pages/inicio/inicio.component').then((m) => m.InicioComponent)
   },
   {
     path: 'terms',
-    component: TermsComponent
-
+    loadComponent: () =>
+      import('./components/terms/terms.component').then((m) => m.TermsComponent)
   },
   {
     path: 'politica-de-privacidade',
-    component: PolicyComponent
-
+    loadComponent: () =>
+      import('./components/policy/policy.component').then((m) => m.PolicyComponent)
   },
   {
     path: 'politica-de-cookies',
-    component: PolicyCookiesComponent
-
+    loadComponent: () =>
+      import('./components/policy-cookies/policy-cookies.component').then((m) => m.PolicyCookiesComponent)
   },
   {
     path: 'ticket/:id',
-    component: TicketComponent
+    loadComponent: () =>
+      import('./components/ticket/ticket.component').then((m) => m.TicketComponent)
   },
   {
     path: 'dashboard',
-    component: DashboardComponent,
-    canActivate: [AuthGuard]
+    canActivate: [AuthGuard],
+    loadComponent: () =>
+      import('./pages/dashboard/dashboard.component').then((m) => m.DashboardComponent)
   },
   {
     path: 'cadastro',
-    component: RegistroComponent
+    loadComponent: () =>
+      import('./pages/registro/registro.component').then((m) => m.RegistroComponent)
   },
   {
     path: 'allowlist',
-    component: AllowlistComponent,
-    canActivate: [allowlistGuard]
+    canActivate: [allowlistGuard],
+    loadComponent: () =>
+      import('./pages/allowlist/allowlist.component').then((m) => m.AllowlistComponent)
   },
   {
     path: '**',
-    component: NotFoundComponent
+    loadComponent: () =>
+      import('./pages/not-found/not-found.component').then((m) => m.NotFoundComponent)
   }
 ];
+

--- a/src/app/components/policy-cookies/policy-cookies.component.ts
+++ b/src/app/components/policy-cookies/policy-cookies.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-policy-cookies',
+  standalone: true,
   imports: [],
   templateUrl: './policy-cookies.component.html',
   styleUrl: './policy-cookies.component.scss'

--- a/src/app/components/policy/policy.component.ts
+++ b/src/app/components/policy/policy.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-policy',
+  standalone: true,
   imports: [],
   templateUrl: './policy.component.html',
   styleUrl: './policy.component.scss'

--- a/src/app/components/terms/terms.component.ts
+++ b/src/app/components/terms/terms.component.ts
@@ -2,6 +2,7 @@ import { Component, input } from '@angular/core';
 
 @Component({
   selector: 'app-terms',
+  standalone: true,
   imports: [],
   templateUrl: './terms.component.html',
   styleUrl: './terms.component.scss'

--- a/src/app/components/ticket/ticket.component.ts
+++ b/src/app/components/ticket/ticket.component.ts
@@ -11,6 +11,7 @@ import { AutoResizeDirective } from '../../auto-resize.directive';
 
 @Component({
   selector: 'app-ticket',
+  standalone: true,
   imports: [DialogModule, CommonModule, SelectModule, FormsModule, InputTextModule, TextareaModule],
 
   templateUrl: './ticket.component.html',

--- a/src/app/pages/allowlist/allowlist.component.ts
+++ b/src/app/pages/allowlist/allowlist.component.ts
@@ -13,6 +13,7 @@ import { LogService } from '../../service/log.service';
 
 @Component({
   selector: 'app-allowlist',
+  standalone: true,
   imports: [
     CommonModule,
     AllowAprovadComponent,

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -29,6 +29,7 @@ import { TicketComponent } from '../../components/ticket/ticket.component';
 
 @Component({
   selector: 'app-dashboard',
+  standalone: true,
   imports: [
     CommonModule,
     MatTabsModule,

--- a/src/app/pages/not-found/not-found.component.ts
+++ b/src/app/pages/not-found/not-found.component.ts
@@ -3,6 +3,7 @@ import { RouterModule } from '@angular/router';
 
 @Component({
     selector: 'app-not-found',
+    standalone: true,
     imports: [RouterModule],
     templateUrl: './not-found.component.html',
     styleUrl: './not-found.component.scss'


### PR DESCRIPTION
## Summary
- lazy load routes via dynamic `loadComponent`
- convert major pages to standalone components
- configure router root with preloading strategy

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5855969c8331b3e0ae0b4053dd19