### PR TITLE
Add SEO files and metadata for legal pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://seu-dominio/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://seu-dominio/terms</loc>
+  </url>
+  <url>
+    <loc>https://seu-dominio/politica-de-privacidade</loc>
+  </url>
+  <url>
+    <loc>https://seu-dominio/politica-de-cookies</loc>
+  </url>
+</urlset>

--- a/src/app/components/breadcrumb/breadcrumb.component.html
+++ b/src/app/components/breadcrumb/breadcrumb.component.html
@@ -1,0 +1,8 @@
+<nav aria-label="breadcrumb" *ngIf="crumbs?.length">
+  <ol class="breadcrumb">
+    <li *ngFor="let crumb of crumbs; let last = last" class="breadcrumb-item" [class.active]="last">
+      <a *ngIf="!last && crumb.url; else lastLabel" [href]="crumb.url">{{ crumb.label }}</a>
+      <ng-template #lastLabel>{{ crumb.label }}</ng-template>
+    </li>
+  </ol>
+</nav>

--- a/src/app/components/breadcrumb/breadcrumb.component.scss
+++ b/src/app/components/breadcrumb/breadcrumb.component.scss
@@ -1,0 +1,11 @@
+.breadcrumb {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.breadcrumb-item + .breadcrumb-item::before {
+  content: '>';
+  margin: 0 0.5rem;
+}

--- a/src/app/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/components/breadcrumb/breadcrumb.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface BreadcrumbItem {
+  label: string;
+  url?: string;
+}
+
+@Component({
+  selector: 'app-breadcrumb',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './breadcrumb.component.html',
+  styleUrl: './breadcrumb.component.scss'
+})
+export class BreadcrumbComponent {
+  @Input() crumbs: BreadcrumbItem[] = [];
+}

--- a/src/app/components/policy-cookies/policy-cookies.component.html
+++ b/src/app/components/policy-cookies/policy-cookies.component.html
@@ -1,4 +1,5 @@
 <main>
+    <app-breadcrumb [crumbs]="[{ label: 'Home', url: '/' }, { label: 'Política de Cookies' }]" />
     <h1>Política de Cookies - Groove Roleplay</h1>
     <div class="container">
         <section class="privacy-content">
@@ -19,4 +20,13 @@
                 afetadas.</p>
         </section>
     </div>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Política de Cookies",
+        "description": "Informações sobre o uso de cookies no Groove Roleplay.",
+        "url": "https://seu-dominio/politica-de-cookies"
+    }
+    </script>
 </main>

--- a/src/app/components/policy-cookies/policy-cookies.component.ts
+++ b/src/app/components/policy-cookies/policy-cookies.component.ts
@@ -1,12 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
+import { BreadcrumbComponent } from '../breadcrumb/breadcrumb.component';
 
 @Component({
   selector: 'app-policy-cookies',
   standalone: true,
-  imports: [],
+  imports: [BreadcrumbComponent],
   templateUrl: './policy-cookies.component.html',
   styleUrl: './policy-cookies.component.scss'
 })
-export class PolicyCookiesComponent {
+export class PolicyCookiesComponent implements OnInit {
+  constructor(private titleService: Title, private meta: Meta) {}
 
+  ngOnInit(): void {
+    this.titleService.setTitle('Política de Cookies - Groove Roleplay');
+    this.meta.updateTag({
+      name: 'description',
+      content: 'Entenda como usamos cookies no Groove Roleplay.'
+    });
+  }
 }

--- a/src/app/components/policy/policy.component.html
+++ b/src/app/components/policy/policy.component.html
@@ -1,4 +1,5 @@
 <main>
+    <app-breadcrumb [crumbs]="[{ label: 'Home', url: '/' }, { label: 'Política de Privacidade' }]" />
     <h1>Política de Privacidade - Groove Roleplay</h1>
     <div class="container">
         <section class="privacy-content">
@@ -26,4 +27,13 @@
             </ul>
         </section>
     </div>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "PrivacyPolicy",
+        "name": "Política de Privacidade",
+        "description": "Como o Groove Roleplay trata seus dados pessoais.",
+        "url": "https://seu-dominio/politica-de-privacidade"
+    }
+    </script>
 </main>

--- a/src/app/components/policy/policy.component.ts
+++ b/src/app/components/policy/policy.component.ts
@@ -1,12 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
+import { BreadcrumbComponent } from '../breadcrumb/breadcrumb.component';
 
 @Component({
   selector: 'app-policy',
   standalone: true,
-  imports: [],
+  imports: [BreadcrumbComponent],
   templateUrl: './policy.component.html',
   styleUrl: './policy.component.scss'
 })
-export class PolicyComponent {
+export class PolicyComponent implements OnInit {
+  constructor(private titleService: Title, private meta: Meta) {}
 
+  ngOnInit(): void {
+    this.titleService.setTitle('Política de Privacidade - Groove Roleplay');
+    this.meta.updateTag({
+      name: 'description',
+      content: 'Saiba como tratamos seus dados pessoais no Groove Roleplay.'
+    });
+  }
 }

--- a/src/app/components/terms/terms.component.html
+++ b/src/app/components/terms/terms.component.html
@@ -1,4 +1,5 @@
 <main>
+    <app-breadcrumb [crumbs]="[{ label: 'Home', url: '/' }, { label: 'Termos' }]" />
     <h1>Termos de Serviço  - Groove Roleplay</h1>
     <section class="terms-content">
         <h2>1. Introdução</h2>
@@ -48,4 +49,13 @@
         </ul>
 
     </section>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Termos de Serviço",
+        "description": "Termos de serviço do Groove Roleplay.",
+        "url": "https://seu-dominio/terms"
+    }
+    </script>
 </main>

--- a/src/app/components/terms/terms.component.ts
+++ b/src/app/components/terms/terms.component.ts
@@ -1,13 +1,25 @@
-import { Component, input } from '@angular/core';
+import { Component, OnInit, input } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
+import { BreadcrumbComponent } from '../breadcrumb/breadcrumb.component';
 
 @Component({
   selector: 'app-terms',
   standalone: true,
-  imports: [],
+  imports: [BreadcrumbComponent],
   templateUrl: './terms.component.html',
   styleUrl: './terms.component.scss'
 })
-export class TermsComponent {
+export class TermsComponent implements OnInit {
   title = input('title');
   terms = input('terms');
+
+  constructor(private titleService: Title, private meta: Meta) {}
+
+  ngOnInit(): void {
+    this.titleService.setTitle('Termos de Serviço - Groove Roleplay');
+    this.meta.updateTag({
+      name: 'description',
+      content: 'Leia os Termos de Serviço do Groove Roleplay.'
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- add sitemap.xml and robots.txt
- add Title, Meta tags and JSON-LD to Terms, Privacy Policy, and Cookies Policy pages
- create reusable breadcrumb component and integrate into legal pages

## Testing
- `npm test` *(fails: ng not found)*
- `npm ci` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68aa831e9d8c8331b59c72c7e2a612e7